### PR TITLE
Add antenna argument for LimeSDR users; add -A shortcut for ATV on 433.25MHz; alternative test logo; README updates

### DIFF
--- a/README
+++ b/README
@@ -56,3 +56,9 @@ $ hacktv -f 551250000 -m i -g 47 --teletext teefax test
 
 -Philip Heron <phil@sanslogic.co.uk>
 
+
+
+New Features from James Dallas, AD5NL (jim.dallas@gmail.com):
+
+1. -b / --band argument for LimeSDR.
+2. my_test.c demonstrates how to change the test pattern to include your own call sign, name, poetic musings, ASCII art, whatever.

--- a/README
+++ b/README
@@ -62,3 +62,4 @@ New Features from James Dallas, AD5NL (jim.dallas@gmail.com):
 
 1. -b / --band argument for LimeSDR.
 2. my_test.c demonstrates how to change the test pattern to include your own call sign, name, poetic musings, ASCII art, whatever.
+2. -A / --amateur argument for amateur television in the US; uses CATV channel 59.

--- a/hack_it
+++ b/hack_it
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CALLSIGN="AD5NL/4"
+NAME="JAMES"
+LOCATION="COLUMBIA TN USA"
+GRID="EM65"
+POWER="27 dBM"
+
+#hacktv -o soapysdr:driver=lime,soapy=0 -m m -f 55250000 -s9000000 -g 50 -b1 ffmpeg:/dev/video0
+#hacktv -o soapysdr:driver=lime,soapy=0 -m m -f 55250000 -s13500000 -g 50 test
+
+v4l2-ctl -d /dev/video0 --set-fmt-video=width=720,height=480,pixelformat=YUY2
+v4l2-ctl -d /dev/video0 -p 30000/1001
+rm /tmp/testfifo.mp4
+mkfifo /tmp/testfifo.mp4
+hacktv -o soapysdr:driver=lime,soapy=0 -m m -A -s9000000 -g64 -b1 ffmpeg:/tmp/testfifo.mp4 > /dev/null 2>&1 &
+
+ffmpeg -hide_banner -loglevel panic -f pulse -i default -f v4l2 -i /dev/video0 -r ntsc -vf "drawtext=text='|  ${CALLSIGN}  |  ${NAME}  |  ${LOCATION}  |  ${GRID}  | ${POWER} |                .': fontcolor=white: fontsize=20: box=1: boxcolor=black@0.5: boxborderw=10: x=20: y=20, drawtext=text='|  ON-AIR for %{pts\:gmtime\:0\:%M\\\\\:%S}                    %{localtime\:%Y %b %d %H.%M.%S %Z}        .': fontcolor=white: fontsize=20: box=1: boxcolor=black@0.5: boxborderw=10: x=20: y=440" -f mpegts pipe:1 > /tmp/testfifo.mp4

--- a/hacktv.c
+++ b/hacktv.c
@@ -108,6 +108,8 @@ static void print_usage(void)
 		"  -b, --band <value>             Set the antenna band (1=Lo, 2=Hi) for LimeSDR.\n"
 		"\n"
 #endif
+		"  -A, --amateur <value>          Set frequency to CATV channel 59 (433.25 MHz), alternative to using -f/--frequency\n"
+		"\n" 
 		"File output options\n"
 		"\n"
 		"  -o, --output file:<filename>   Open a file for output. Use - for stdout.\n"
@@ -226,6 +228,7 @@ int main(int argc, char *argv[])
 		{ "amp",        no_argument,       0, 'a' },
 		{ "gain",       required_argument, 0, 'x' },
 		{ "band",	required_argument, 0, 'b' },
+		{ "amateur",	no_argument,	   0, 'A' },
 		{ "type",       required_argument, 0, 't' },
 		{ 0,            0,                 0,  0  }
 	};
@@ -259,7 +262,7 @@ int main(int argc, char *argv[])
 	s.file_type = HACKTV_INT16;
 	
 	opterr = 0;
-	while((c = getopt_long(argc, argv, "o:m:s:G:rvf:ag:b:t:", long_options, &option_index)) != -1)
+	while((c = getopt_long(argc, argv, "o:m:s:G:rvf:ag:b:At:", long_options, &option_index)) != -1)
 	{
 		switch(c)
 		{
@@ -367,7 +370,11 @@ int main(int argc, char *argv[])
 		case 'b': /* -b, --band <value> */
 			s.band = atoi(optarg);
 			break;
-		
+	
+		case 'A': /* -A, --amateur */
+			s.frequency = 433250000;
+			break;
+
 		case 't': /* -t, --type <type> */
 			
 			if(strcmp(optarg, "uint8") == 0)

--- a/hacktv.c
+++ b/hacktv.c
@@ -105,6 +105,7 @@ static void print_usage(void)
 		"  -o, --output soapysdr[:<opts>] Open a SoapySDR device for output.\n"
 		"  -f, --frequency <value>        Set the RF frequency in Hz.\n"
 		"  -g, --gain <value>             Set the TX level. Default: 0dB\n"
+		"  -b, --band <value>             Set the antenna band (1=Lo, 2=Hi) for LimeSDR.\n"
 		"\n"
 #endif
 		"File output options\n"
@@ -224,6 +225,7 @@ int main(int argc, char *argv[])
 		{ "frequency",  required_argument, 0, 'f' },
 		{ "amp",        no_argument,       0, 'a' },
 		{ "gain",       required_argument, 0, 'x' },
+		{ "band",	required_argument, 0, 'b' },
 		{ "type",       required_argument, 0, 't' },
 		{ 0,            0,                 0,  0  }
 	};
@@ -253,10 +255,11 @@ int main(int argc, char *argv[])
 	s.frequency = 0;
 	s.amp = 0;
 	s.gain = 0;
+	s.band = 99;
 	s.file_type = HACKTV_INT16;
 	
 	opterr = 0;
-	while((c = getopt_long(argc, argv, "o:m:s:G:rvf:ag:t:", long_options, &option_index)) != -1)
+	while((c = getopt_long(argc, argv, "o:m:s:G:rvf:ag:b:t:", long_options, &option_index)) != -1)
 	{
 		switch(c)
 		{
@@ -359,6 +362,10 @@ int main(int argc, char *argv[])
 		
 		case 'g': /* -g, --gain <value> */
 			s.gain = atoi(optarg);
+			break;
+
+		case 'b': /* -b, --band <value> */
+			s.band = atoi(optarg);
 			break;
 		
 		case 't': /* -t, --type <type> */
@@ -505,7 +512,7 @@ int main(int argc, char *argv[])
 #ifdef HAVE_SOAPYSDR
 	else if(strcmp(s.output_type, "soapysdr") == 0)
 	{
-		if(rf_soapysdr_open(&s, s.output, s.frequency, s.gain) != HACKTV_OK)
+		if(rf_soapysdr_open(&s, s.output, s.frequency, s.gain, s.band) != HACKTV_OK)
 		{
 			vid_free(&s.vid);
 			return(-1);

--- a/hacktv.h
+++ b/hacktv.h
@@ -68,6 +68,7 @@ typedef struct {
 	uint64_t frequency;
 	int amp;
 	int gain;
+	int band;
 	int file_type;
 	
 	/* Video encoder state */

--- a/my_test.c
+++ b/my_test.c
@@ -1,0 +1,214 @@
+/* hacktv - Analogue video transmitter for the HackRF                    */
+/*=======================================================================*/
+/* Copyright 2017 Philip Heron <phil@sanslogic.co.uk>                    */
+/*                                                                       */
+/* This program is free software: you can redistribute it and/or modify  */
+/* it under the terms of the GNU General Public License as published by  */
+/* the Free Software Foundation, either version 3 of the License, or     */
+/* (at your option) any later version.                                   */
+/*                                                                       */
+/* This program is distributed in the hope that it will be useful,       */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of        */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         */
+/* GNU General Public License for more details.                          */
+/*                                                                       */
+/* You should have received a copy of the GNU General Public License     */
+/* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+#include <math.h>
+#include <stdlib.h>
+#include "hacktv.h"
+
+/* A small 2-bit hacktv logo */
+
+/*#define LOGO_WIDTH  48*/
+#define LOGO_WIDTH  60
+#define LOGO_HEIGHT 9
+/*#define LOGO_SCALE 4*/
+#define LOGO_SCALE  2
+/*
+static const char *_logo =
+	"                                                "
+	" ##  ##    ##     ####   ##  ##  ######  ##  ## "
+	" ##  ##   ####   ##  ##  ## ##     ##    ##  ## "
+	" ##  ##  ##  ##  ##      ####      ##    ##  ## "
+	" ######  ######  ##      ###       ##    ##  ## "
+	" ##  ##  ##  ##  ##      ####      ##    ##  ## "
+	" ##  ##  ##  ##  ##  ##  ## ##     ##     ####  "
+	" ##  ##  ##  ##   ####   ##  ##    ##      ##   "
+	"                                                ";
+*/
+static const char *_logo =
+	"                                                            "
+	"    ##    ######   #######  ##   ##  ##         ##   ##     " 
+	"   ####   ##   ##  ##       ###  ##  ##         ##   ##     "
+	"  ##  ##  ##   ##  ##       #### ##  ##         ##   ##     "
+	"  ######  ##   ##  ######   ## ####  ##                     "
+	"  ##  ##  ##   ##       ##  ##  ###  ##       ##       ##   "
+	"  ##  ##  ##   ##  ##   ##  ##   ##  ##       ###     ###   "
+	"  ##  ##  ######    #####   ##   ##  ######    #########    "
+	"                                                            ";  
+
+/* AV test pattern source */
+typedef struct {
+	int width;
+	int height;
+	uint32_t *video;
+	int16_t *audio;
+	size_t audio_samples;
+} av_test_t;
+
+static uint32_t *_av_test_read_video(void *private, float *ratio)
+{
+	av_test_t *av = private;
+	if(ratio) *ratio = 4.0 / 3.0;
+	return(av->video);
+}
+
+static int16_t *_av_test_read_audio(void *private, size_t *samples)
+{
+	av_test_t *av = private;
+	*samples = av->audio_samples;
+	return(av->audio);
+}
+
+static int _av_test_close(void *private)
+{
+	av_test_t *av = private;
+	if(av->video) free(av->video);
+	if(av->audio) free(av->audio);
+	free(av);
+	return(HACKTV_OK);
+}
+
+int av_test_open(vid_t *s)
+{
+	uint32_t const bars[8] = {
+		0x000000,
+		0x0000FF,
+		0xFF0000,
+		0xFF00FF,
+		0x00FF00,
+		0x00FFFF,
+		0xFFFF00,
+		0xFFFFFF,
+	};
+	av_test_t *av;
+	int c, x, y;
+	double d;
+	int16_t l;
+	
+	av = calloc(1, sizeof(av_test_t));
+	if(!av)
+	{
+		return(HACKTV_OUT_OF_MEMORY);
+	}
+	
+	/* Generate a basic test pattern */
+	av->width = s->active_width;
+	av->height = s->conf.active_lines;
+	av->video = malloc(vid_get_framebuffer_length(s));
+	if(!av->video)
+	{
+		free(av);
+		return(HACKTV_OUT_OF_MEMORY);
+	}
+	
+	for(y = 0; y < s->conf.active_lines; y++)
+	{
+		for(x = 0; x < s->active_width; x++)
+		{
+			if(y < s->conf.active_lines - 140)
+			{
+				/* 100% colour bars */
+				c = 7 - x * 8 / s->active_width;
+				c = bars[c];
+			}
+			else if(y < s->conf.active_lines - 120)
+			{
+				/* 100% red */
+				c = 0xFF0000;
+			}
+			else if(y < s->conf.active_lines - 100)
+			{
+				/* Gradient black to white */
+				c = x * 0xFF / (s->active_width - 1);
+				c = c << 16 | c << 8 | c;
+			}
+			else
+			{
+				/* 8 level grey bars */
+				c = x * 0xFF / (s->active_width - 1);
+				c &= 0xE0;
+				c = c | (c >> 3) | (c >> 6);
+				c = c << 16 | c << 8 | c;
+			}
+			
+			av->video[y * s->active_width + x] = c;
+		}
+	}
+	
+	/* Overlay the logo */
+	x = s->active_width / 2;
+	y = s->conf.active_lines / 10;
+	
+	for(x = 0; x < LOGO_WIDTH * LOGO_SCALE; x++)
+	{
+		for(y = 0; y < LOGO_HEIGHT * LOGO_SCALE; y++)
+		{
+			c = _logo[y / LOGO_SCALE * LOGO_WIDTH + x / LOGO_SCALE] == ' ' ? 0x000000 : 0xFFFFFF;
+			
+			av->video[(s->conf.active_lines / 10 + y) * s->active_width + ((s->active_width - LOGO_WIDTH * LOGO_SCALE) / 2) + x] = c;
+		}
+	}
+	
+	/* Generate the 1khz test tones (BBC 1 style) */
+	d = 1000.0 * 2 * M_PI / HACKTV_AUDIO_SAMPLE_RATE;
+	y = HACKTV_AUDIO_SAMPLE_RATE * 64 / 100; /* 640ms */
+	av->audio_samples = y * 10; /* 6.4 seconds */
+	av->audio = malloc(av->audio_samples * 2 * sizeof(int16_t));
+	if(!av->audio)
+	{
+		free(av);
+		return(HACKTV_OUT_OF_MEMORY);
+	}
+	
+	for(x = 0; x < av->audio_samples; x++)
+	{
+		l = sin(x * d) * INT16_MAX * 0.1;
+		
+		if(x < y)
+		{
+			/* 0 - 640ms, interrupt left channel */
+			av->audio[x * 2 + 0] = 0;
+			av->audio[x * 2 + 1] = l;
+		}
+		else if(x >= y * 2 && x < y * 3)
+		{
+			/* 1280ms - 1920ms, interrupt right channel */
+			av->audio[x * 2 + 0] = l;
+			av->audio[x * 2 + 1] = 0;
+		}
+		else if(x >= y * 4 && x < y * 5)
+		{
+			/* 2560ms - 3200ms, interrupt right channel again */
+			av->audio[x * 2 + 0] = l;
+			av->audio[x * 2 + 1] = 0;
+		}
+		else
+		{
+			/* Use both channels for all other times */
+			av->audio[x * 2 + 0] = l; /* Left */
+			av->audio[x * 2 + 1] = l; /* Right */
+		}
+	}
+	
+	/* Register the callback functions */
+	s->av_private = av;
+	s->av_read_video = _av_test_read_video;
+	s->av_read_audio = _av_test_read_audio;
+	s->av_close = _av_test_close;
+	
+	return(HACKTV_OK);
+}
+

--- a/soapysdr.c
+++ b/soapysdr.c
@@ -52,7 +52,7 @@ static int _close(void *private)
 	return(HACKTV_OK);
 }
 
-int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz, unsigned int gain)
+int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz, unsigned int gain, unsigned int band)
 {
 	soapysdr_t *rf;
 	SoapySDRKwargs *results;
@@ -124,7 +124,32 @@ int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz,
 		free(rf);
 		return(HACKTV_ERROR);
 	}
+
+	/* Added to work with LimeSDR */
+
+	if (band < 99)
+	{
+		if (band == 1)
+		{
+			if(SoapySDRDevice_setAntenna(rf->d, SOAPY_SDR_TX, 0, "BAND1") !=0)
+			{
+				fprintf(stderr, "SoapySDRDevice_setAntenna() failed: %s\n", SoapySDRDevice_lastError());
+				free(rf);
+				return(HACKTV_ERROR);
+			}
+		}
 	
+		if (band == 2)
+		{
+       	       		if(SoapySDRDevice_setAntenna(rf->d, SOAPY_SDR_TX, 0, "BAND2") !=0)
+                       {
+                               fprintf(stderr, "SoapySDRDevice_setAntenna() failed: %s\n", SoapySDRDevice_lastError());
+                               free(rf);
+                               return(HACKTV_ERROR);
+                       }
+		}
+	}
+
 	if(SoapySDRDevice_setupStream(rf->d, &rf->s, SOAPY_SDR_TX, SOAPY_SDR_CS16, NULL, 0, NULL) != 0)
 	{
 		fprintf(stderr, "SoapySDRDevice_setupStream() failed: %s\n", SoapySDRDevice_lastError());

--- a/soapysdr.c
+++ b/soapysdr.c
@@ -137,6 +137,13 @@ int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz,
 				free(rf);
 				return(HACKTV_ERROR);
 			}
+                        
+			if(SoapySDRDevice_setBandwidth(rf->d, SOAPY_SDR_TX, 0, 9000000) !=0)
+                        {
+                                fprintf(stderr, "SoapySDRDevice_setiBandwidth() failed: %s\n", SoapySDRDevice_lastError());
+                                free(rf);
+                                return(HACKTV_ERROR);
+                        }
 		}
 	
 		if (band == 2)
@@ -147,6 +154,13 @@ int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz,
                                free(rf);
                                return(HACKTV_ERROR);
                        }
+                        if(SoapySDRDevice_setBandwidth(rf->d, SOAPY_SDR_TX, 0, 9000000) !=0)
+                        {
+                                fprintf(stderr, "SoapySDRDevice_setBandwidth() failed: %s\n", SoapySDRDevice_lastError());
+                                free(rf);
+                                return(HACKTV_ERROR);
+                        }
+
 		}
 	}
 

--- a/soapysdr.h
+++ b/soapysdr.h
@@ -18,7 +18,7 @@
 #ifndef _SOAPYSDR_H
 #define _SOAPYSDR_H
 
-extern int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz, unsigned int gain);
+extern int rf_soapysdr_open(hacktv_t *s, const char *device, unsigned int frequency_hz, unsigned int gain, unsigned int band);
 
 #endif
 


### PR DESCRIPTION
Sharing some custom code that I added to make my life easier:

1. When I first started experimenting with SoapySDR and LimeSDR with HackTV, I had problems because I believe the antenna setting on the Lime was defaulting to NONE. I added an argument that allows one (if specified) to set it to BAND1 or BAND2 instead. On the Lime BAND1 is for HF/VHF/UHF and BAND2 is for UHF/SHF (better gain on 23cm and 13cm for example).

This is implemented using new -b / --band argument.

2. I also added an argument -A / --amateur to set the frequency to 433.25 MHz (approx. same as Channel 59 CATV in the US). This is a common amateur frequency.

3. I added my_test.c which is a variant of test.c. Copying my_test.c over test.c and then doing make / make install will show my custom AD5NL :) logo instead. Intended as an example of how to alter test.c for custom purposes.

4. I made a few changes to README to document my changes above.