### PR TITLE
Fix levels of colourburst and modulated chroma.

### DIFF
--- a/video.c
+++ b/video.c
@@ -1912,8 +1912,8 @@ static int16_t *_vid_next_line(vid_t *s, size_t *samples)
 			
 			if(pal)
 			{
-				s->output[x * 2] += (s->i_level_lookup[rgb] * lut_i[x]) >> 16;
-				s->output[x * 2] += (s->q_level_lookup[rgb] * lut_q[x]) >> 16;
+				s->output[x * 2] += (s->i_level_lookup[rgb] * lut_i[x]) >> 15;
+				s->output[x * 2] += (s->q_level_lookup[rgb] * lut_q[x]) >> 15;
 			}
 		}
 	}
@@ -1941,8 +1941,8 @@ static int16_t *_vid_next_line(vid_t *s, size_t *samples)
 			
 			if(pal)
 			{
-				s->output[x * 2] += (s->i_level_lookup[rgb] * lut_i[x]) >> 16;
-				s->output[x * 2] += (s->q_level_lookup[rgb] * lut_q[x]) >> 16;
+				s->output[x * 2] += (s->i_level_lookup[rgb] * lut_i[x]) >> 15;
+				s->output[x * 2] += (s->q_level_lookup[rgb] * lut_q[x]) >> 15;
 			}
 		}
 	}
@@ -1969,7 +1969,7 @@ static int16_t *_vid_next_line(vid_t *s, size_t *samples)
 	{
 		for(x = s->burst_left; x < s->burst_left + s->burst_width; x++)
 		{
-			s->output[x * 2] += (lut_b[x] * s->burst_level) >> 16;
+			s->output[x * 2] += (lut_b[x] * s->burst_level) >> 15;
 		}
 	}
 	


### PR DESCRIPTION
hacktv's PAL waveform for `test:colourbars` (100% bars) currently looks like this:

![hacktv-waveform](https://user-images.githubusercontent.com/436317/63965259-aa228080-ca90-11e9-9b95-1794cb36a71f.png)

The colourburst and modulated chroma should be twice the amplitude shown there -- compare with the 100% bars waveform on [Pembers' site](https://www.radios-tv.co.uk/Pembers/Test-Cards/Test-Card-Technical.html#Bars).

Fixing this works OK for PAL, but for NTSC the output now clips (because the maximum excursion is a bit bigger and there's not quite enough headroom) - I'm not sure whether it'd be better to reduce the level a bit in the `vid_config_t`s, or to make the test code generate 75% bars...