### PR TITLE
Fix typing errors

### DIFF
--- a/eurocrypt.c
+++ b/eurocrypt.c
@@ -396,7 +396,7 @@ static void _ecm_hash(uint8_t *hash, const uint8_t *src, const ec_mode_t *mode)
 		}
 	}
 	
-	/* Final interation - EC M only */
+	/* Final iteration - EC M only */
 	if(mode->emode == EC_M)
 	{
 		_eurocrypt(hash, hash, mode->key, HASH, mode->emode);

--- a/hacktv.1
+++ b/hacktv.1
@@ -336,7 +336,7 @@ free
 .IP
 conditional = A valid Sky card is required to decode. Sample data from MTV.
 .PP
-Videocrypt is only compatiable with 625 line PAL modes. This version
+Videocrypt is only compatible with 625 line PAL modes. This version
 works best when used with samples rates at multiples of 14MHz.
 .PP
 Videocrypt II

--- a/hacktv.c
+++ b/hacktv.c
@@ -256,7 +256,7 @@ static void print_usage(void)
 		"  free        = Free-access, no subscription card is required to decode.\n"
 		"  conditional = A valid Sky card is required to decode. Sample data from MTV.\n"
 		"\n"
-		"Videocrypt is only compatiable with 625 line PAL modes. This version\n"
+		"Videocrypt is only compatible with 625 line PAL modes. This version\n"
 		"works best when used with samples rates at multiples of 14MHz.\n"
 		"\n"
 		"Videocrypt II\n"

--- a/mac.c
+++ b/mac.c
@@ -844,7 +844,7 @@ int mac_init(vid_t *s)
 	
 	mac->vsam = MAC_VSAM_FREE_ACCESS;
 	
-	/* Initalise Eurocrypt, if required */
+	/* Initialise Eurocrypt, if required */
 	if(s->conf.eurocrypt)
 	{
 		mac->vsam = MAC_VSAM_CONTROLLED_ACCESS;
@@ -1118,7 +1118,7 @@ static int _line_625(vid_t *s, int frame, int line, uint8_t *data, int x)
 	dx = _bits(df, dx, b, 8);
 	
 	dx = _bits(df, dx, (frame >> 8) & 0xFFFFF, 20);    /* CAFCNT Conditional access frame count */
-	dx = _bits(df, dx, 1, 1);                          /* Rp Repacement */
+	dx = _bits(df, dx, 1, 1);                          /* Rp Replacement */
 	dx = _bits(df, dx, 1, 1);                          /* Fp Fingerprint */
 	dx = _bits(df, dx, 3, 2);                          /* Unallocated, both bits set to 1 */
 	dx = _bits(df, dx, 0, 1);                          /* SIFT Service identification channel format */

--- a/video.c
+++ b/video.c
@@ -3485,7 +3485,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 	s->olines = 1;
 	s->audio = 0;
 	
-	/* Initalise D/D2-MAC state */
+	/* Initialise D/D2-MAC state */
 	if(s->conf.type == VID_MAC)
 	{
 		r = mac_init(s);
@@ -3502,7 +3502,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 		_add_lineprocess(s, "raster", 1, NULL, _vid_next_line_raster, NULL);
 	}
 	
-	/* Initalise VITS inserter */
+	/* Initialise VITS inserter */
 	if(s->conf.vits)
 	{
 		if((r = vits_init(&s->vits, s->pixel_rate, s->width, s->conf.lines, s->white_level - s->blanking_level)) != VID_OK)
@@ -3514,7 +3514,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 		_add_lineprocess(s, "vits", 1, &s->vits, vits_render, NULL);
 	}
 	
-	/* Initalise the WSS system */
+	/* Initialise the WSS system */
 	if(s->conf.wss)
 	{
 		if((r = wss_init(&s->wss, s, s->conf.wss)) != VID_OK)
@@ -3550,7 +3550,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 		_add_lineprocess(s, "videocrypts", VCS_DELAY_LINES, &s->vcs, vcs_render_line, NULL);
 	}
 	
-	/* Initalise syster encoder */
+	/* Initialise syster encoder */
 	if(s->conf.syster)
 	{
 		if((r = ng_init(&s->ng, s)) != VID_OK)
@@ -3562,7 +3562,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 		_add_lineprocess(s, "syster", NG_DELAY_LINES, &s->ng, ng_render_line, NULL);
 	}
 	
-	/* Initalise ACP renderer */
+	/* Initialise ACP renderer */
 	if(s->conf.acp)
 	{
 		if((r = acp_init(&s->acp, s)) != VID_OK)
@@ -3574,7 +3574,7 @@ int vid_init(vid_t *s, unsigned int sample_rate, unsigned int pixel_rate, const 
 		_add_lineprocess(s, "acp", 1, &s->acp, acp_render_line, NULL);
 	}
 	
-	/* Initalise the teletext system */
+	/* Initialise the teletext system */
 	if(s->conf.teletext)
 	{
 		if((r = tt_init(&s->tt, s, s->conf.teletext)) != VID_OK)

--- a/videocrypts.c
+++ b/videocrypts.c
@@ -19,7 +19,7 @@
  * 
  * This is untested on real hardware and should be considered just a
  * simulation. The VBI data *may* be valid but the shuffling sequence
- * is definitly not. There may also be colour distortion due to hacktv
+ * is definitely not. There may also be colour distortion due to hacktv
  * not operating at the specified sample rate of FPAL * 4.
 */
 


### PR DESCRIPTION
There is a small error in the man page and in the text from --help (it's the same word, "compatiable") and in some comments.

I'm in doubt about this "Replacement":
	dx = _bits(df, dx, 1, 1);                          /* Rp Repacement */
	dx = _bits(df, dx, 1, 1);                          /* Rp Replacement */

Found with:
codespell --ignore-words-list=hist,nwo --write-changes --interactive 2